### PR TITLE
Item detail nohheeyeon

### DIFF
--- a/src/main/java/com/shop/entity/OrderItem.java
+++ b/src/main/java/com/shop/entity/OrderItem.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter @Setter

--- a/src/main/resources/templates/item/itemDtl.html
+++ b/src/main/resources/templates/item/itemDtl.html
@@ -1,4 +1,3 @@
-<button type="button" class="btn btn-primary btn-lg" onclick="order()">주문하기</button>
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"


### PR DESCRIPTION
* itemDtl.html의 버튼 태그를 제거했을 때 상품 상세 페이지가 정상적으로 작동했습니다
* 'order()' 함수 내부에 로직 오류가 있었던 걸로 예상됩니다